### PR TITLE
Employeeeditposttest

### DIFF
--- a/HR/templates/HR/employee/addEmployee.html
+++ b/HR/templates/HR/employee/addEmployee.html
@@ -3,9 +3,9 @@
 <h2>Add a New Employee</h2>
 <form action="{% url 'HR:addemployee' %}" method='post'>
   {% csrf_token %}
-  First Name: <input type="text" name="first_name" placeholder="First name"><br />
-  Last Name: <input type="text" name="last_name" placeholder="Last name"><br />
-  Start date: <input type="date" name="start_date"><br />
+  First Name: <input type="text" name="first_name" placeholder="First name" required=true><br />
+  Last Name: <input type="text" name="last_name" placeholder="Last name" required=true><br />
+  Start date: <input type="date" name="start_date" required=true><br />
   Supervisor Status:
   <input type="radio" name="is_supervisor" value=1>Yes
   <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />

--- a/HR/templates/HR/employee/editEmployee.html
+++ b/HR/templates/HR/employee/editEmployee.html
@@ -7,9 +7,9 @@
 <form action="{% url 'HR:editemployee' employee.id %}" method='post'>
 {% csrf_token %}
 
-  First Name: <input type="text" name="first_name" value="{{ first_name }}"><br />
-  Last Name: <input type="text" name="last_name" value="{{ last_name }}"><br />
-  Start date: <input type="date" name="start_date" value="{{ start_date }}"><br />
+  First Name: <input type="text" name="first_name" value="{{ first_name }}" required=true><br />
+  Last Name: <input type="text" name="last_name" value="{{ last_name }}" required=true><br />
+  Start date: <input type="date" name="start_date" value="{{ start_date }}" required=true><br />
   Supervisor Status:
   <input type="radio" name="is_supervisor" value=1>Yes
   <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />

--- a/HR/templates/HR/training/addTraining.html
+++ b/HR/templates/HR/training/addTraining.html
@@ -9,10 +9,10 @@
 <div id="main_container">
     <form method="POST">
         {% csrf_token %}
-        <input type="text" value="{{t.name}}" name="training_name" placeholder="training program name">
-        <input type="date" value="{{t.start_date}}" name="training_startDate" placeholder="start date: YYYY-MM-DD">
-        <input type="date" value="{{t.end_date}}" name="training_endDate" placeholder="end date: YYYY-MM-DD">
-        <input type="text" value="{{t.maxAttendees}}" name="training_maxEnrollment" placeholder="max attendees">
+        <input type="text" value="{{t.name}}" name="training_name" placeholder="training program name" required=true>
+        <input type="date" value="{{t.start_date}}" name="training_startDate" placeholder="start date: YYYY-MM-DD" required=true>
+        <input type="date" value="{{t.end_date}}" name="training_endDate" placeholder="end date: YYYY-MM-DD" required=true>
+        <input type="number" value="{{t.maxAttendees}}" name="training_maxEnrollment" placeholder="max attendees" required=true>
         <input type="submit" value="Save Training">
     </form>
 </div>

--- a/HR/templates/HR/training/editTraining.html
+++ b/HR/templates/HR/training/editTraining.html
@@ -4,10 +4,10 @@
 
 <form action="{% url 'HR:editedTraining' training.id %}" method="POST">
         {% csrf_token %}
-        <input type="text" value="{{training.name}}" name="training_name">
-        <input type="date" value="{{start_date}}" name="training_startDate">
-        <input type="date" value="{{end_date}}" name="training_endDate">
-        <input type="number" value="{{training.maxAttendees}}" name="training_maxEnrollment" required="true">
+        <input type="text" value="{{training.name}}" name="training_name" required=true>
+        <input type="date" value="{{start_date}}" name="training_startDate" required=true>
+        <input type="date" value="{{end_date}}" name="training_endDate" required=true>
+        <input type="number" value="{{training.maxAttendees}}" name="training_maxEnrollment" required=true>
         <input type="submit" value="Save Training">
 </form>
 {% endblock content %}

--- a/HR/test/test_employee_add.py
+++ b/HR/test/test_employee_add.py
@@ -11,10 +11,9 @@ class EmployeeAddTest(TestCase):
   def test_get_employee_form(self):
     response = self.client.get(reverse('HR:addemployee'))
     form_test = 'First Name: <input type="text" name="first_name" placeholder="First name" required=true><br />\n  Last Name: <input type="text" name="last_name" placeholder="Last name" required=true><br />\n  Start date: <input type="date" name="start_date" required=true><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n\n  Department: <select name="department_id" id="employee_department">\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
-    print('FORMTEST', form_test)
     self.assertIn(form_test, response.content)
     
-    # test that data is posting to employee list and routing correctly
+    # test for correct url redirect
 
   def test_post_employee(self):
 
@@ -24,6 +23,5 @@ class EmployeeAddTest(TestCase):
     )
 
     response = self.client.post(reverse('HR:addemployee'), {'first_name': 'Randy', 'last_name': 'Savage', 'start_date': '2000-12-14', 'is_supervisor': 1, "department_id": new_dept.id})
-    print("RESPONSE", response.content)
     # Getting 302 back because we have a success url and the view is redirecting
     self.assertEqual(response.status_code, 302)

--- a/HR/test/test_employee_add.py
+++ b/HR/test/test_employee_add.py
@@ -10,7 +10,7 @@ class EmployeeAddTest(TestCase):
 
   def test_get_employee_form(self):
     response = self.client.get(reverse('HR:addemployee'))
-    form_test = 'First Name: <input type="text" name="first_name" placeholder="First name"><br />\n  Last Name: <input type="text" name="last_name" placeholder="Last name"><br />\n  Start date: <input type="date" name="start_date"><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n\n  Department: <select name="department_id" id="employee_department">\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
+    form_test = 'First Name: <input type="text" name="first_name" placeholder="First name" required=true><br />\n  Last Name: <input type="text" name="last_name" placeholder="Last name" required=true><br />\n  Start date: <input type="date" name="start_date" required=true><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n\n  Department: <select name="department_id" id="employee_department">\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
     print('FORMTEST', form_test)
     self.assertIn(form_test, response.content)
     

--- a/HR/test/test_employee_edit.py
+++ b/HR/test/test_employee_edit.py
@@ -46,12 +46,30 @@ class EmployeeEditTest(TestCase):
     )
     print("EMPLOYEE", new_employee)
 
-    # test whether the get is retrieving template
+    # test whether the get is retrieving template with employee info as existing value
 
     response = self.client.get(reverse('HR:editemployee', args=(new_employee.id,)))
     form_return = 'First Name: <input type="text" name="first_name" value="Emmet"><br />\n  Last Name: <input type="text" name="last_name" value="Ray"><br />\n  Start date: <input type="date" name="start_date" value="2008-05-03"><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n  Department: <select name="department_id" id="employee_department">\n    \n    <option value="1">Department of Stuff</option>\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
     print('FORMRETURN', form_return)
     self.assertIn(form_return, response.content)
 
+    # test that edited info is posting from the form back to the employee detail
+
+  def test_post_edit_employee(self):
+
+    # create instance of employee
+
+    dept_of_things = Department.objects.create(
+      name="Department of Things",
+      budget="10000"
+    )
+    new_employee = Employee.objects.create(
+      first_name="Bruce",
+      last_name="Willis",
+      start_date="2010-05-05",
+      is_supervisor= 1,
+      department_id= dept_of_things.id,
+    )
+    print("EMPLOYEE", new_employee)
 
   

--- a/HR/test/test_employee_edit.py
+++ b/HR/test/test_employee_edit.py
@@ -49,7 +49,6 @@ class EmployeeEditTest(TestCase):
     form_return = 'First Name: <input type="text" name="first_name" value="Emmet" required=true><br />\n  Last Name: <input type="text" name="last_name" value="Ray" required=true><br />\n  Start date: <input type="date" name="start_date" value="2008-05-03" required=true><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n  Department: <select name="department_id" id="employee_department">\n    \n    <option value="1">Department of Stuff</option>\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
     self.assertIn(form_return, response.content)
 
-    # test that edited info is posting from the form back to the employee detail
 
   def test_post_edit_employee(self):
 
@@ -67,7 +66,8 @@ class EmployeeEditTest(TestCase):
       department_id= dept_of_things.id,
     )
 
+    # test for correct url redirect
+
     response = self.client.post(reverse('HR:editemployee', args=(new_employee.id, )), {'first_name': 'Bruce', 'last_name': 'Willis', 'start_date': '2010-05-05', 'is_supervisor': 1, "department_id": dept_of_things.id})
     # Getting 302 back because we have a success url and the view is redirecting
     self.assertEqual(response.status_code, 302)
-

--- a/HR/test/test_employee_edit.py
+++ b/HR/test/test_employee_edit.py
@@ -21,11 +21,9 @@ class EmployeeEditTest(TestCase):
       is_supervisor= 1,
       department_id= new_dept.id,
     )
-    print("EMPLOYEE", new_employee)
 
     # test whether the get is directing to the correct url
     response = self.client.get(reverse('HR:editemployee', args=(new_employee.id,)))
-    print("EDITRESPONSE", response)
     self.assertEqual(response.status_code, 200)
 
 
@@ -44,13 +42,11 @@ class EmployeeEditTest(TestCase):
       is_supervisor= 0,
       department_id= dept_of_stuff.id,
     )
-    print("EMPLOYEE", new_employee)
 
     # test whether the get is retrieving template with employee info as existing value
 
     response = self.client.get(reverse('HR:editemployee', args=(new_employee.id,)))
     form_return = 'First Name: <input type="text" name="first_name" value="Emmet" required=true><br />\n  Last Name: <input type="text" name="last_name" value="Ray" required=true><br />\n  Start date: <input type="date" name="start_date" value="2008-05-03" required=true><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n  Department: <select name="department_id" id="employee_department">\n    \n    <option value="1">Department of Stuff</option>\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
-    print('FORMRETURN', form_return)
     self.assertIn(form_return, response.content)
 
     # test that edited info is posting from the form back to the employee detail
@@ -70,6 +66,8 @@ class EmployeeEditTest(TestCase):
       is_supervisor= 1,
       department_id= dept_of_things.id,
     )
-    print("EMPLOYEE", new_employee)
 
-  
+    response = self.client.post(reverse('HR:editemployee', args=(new_employee.id, )), {'first_name': 'Bruce', 'last_name': 'Willis', 'start_date': '2010-05-05', 'is_supervisor': 1, "department_id": dept_of_things.id})
+    # Getting 302 back because we have a success url and the view is redirecting
+    self.assertEqual(response.status_code, 302)
+

--- a/HR/test/test_employee_edit.py
+++ b/HR/test/test_employee_edit.py
@@ -49,7 +49,7 @@ class EmployeeEditTest(TestCase):
     # test whether the get is retrieving template with employee info as existing value
 
     response = self.client.get(reverse('HR:editemployee', args=(new_employee.id,)))
-    form_return = 'First Name: <input type="text" name="first_name" value="Emmet"><br />\n  Last Name: <input type="text" name="last_name" value="Ray"><br />\n  Start date: <input type="date" name="start_date" value="2008-05-03"><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n  Department: <select name="department_id" id="employee_department">\n    \n    <option value="1">Department of Stuff</option>\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
+    form_return = 'First Name: <input type="text" name="first_name" value="Emmet" required=true><br />\n  Last Name: <input type="text" name="last_name" value="Ray" required=true><br />\n  Start date: <input type="date" name="start_date" value="2008-05-03" required=true><br />\n  Supervisor Status:\n  <input type="radio" name="is_supervisor" value=1>Yes\n  <input type="radio" name="is_supervisor" checked="checked" value=0>No<br />\n  Department: <select name="department_id" id="employee_department">\n    \n    <option value="1">Department of Stuff</option>\n    \n  </select><br /><br />\n  <input type="submit" value="Save Employee">\n</form>\n'.encode()
     print('FORMRETURN', form_return)
     self.assertIn(form_return, response.content)
 

--- a/HR/test/test_employee_list.py
+++ b/HR/test/test_employee_list.py
@@ -3,23 +3,6 @@ from django.test import TestCase
 from django.urls import reverse
 from HR.models.employeeModels import Employee
 
-# Stuff to test
-# context: what we send to the template
-# content: the rendered html
-# response_codes
-
-# Name your tests like this! test_foo so Django can find and run 'em
-
-# * The test client is a Python class that acts as a dummy Web browser, allowing you to test your views and interact with your Django - powered application programmatically. Some of the things you can do with the test client are:
-#     * Simulate GET and POST requests on a URL and observe the response – everything from low - level HTTP(result headers and status codes) to page content.
-#     * See the chain of redirects(if any) and check the URL and status code at each step.
-#     * Test that a given request is rendered by a given Django template, with a template context that contains certain values.
-
-# *  Good rules-of-thumb include having:
-#     * a separate TestClass for each model or view
-#     * a separate test method for each set of conditions you want to test
-#     * test method names that describe their function
-
 class EmployeeListTest(TestCase):
 
     def test_list_employee(self):

--- a/HR/test/test_training_list.py
+++ b/HR/test/test_training_list.py
@@ -18,29 +18,3 @@ class TrainingListTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['training_list']), 1)
         print(new_training)
-from django.utils import timezone
-
-
-    # def test_Training(self):
-    #     training = Training.objects.create(
-    #         name= "deathstar",
-    #         start_date = "1992-3-1",
-    #         end_date= "1993-3-4",
-    #         maxAttendees= 1,
-    #     )
-    #     # Issue a GET request. "client" is a dummy web browser
-    #     # 'reverse' is used to generate a URL for a given view. The main advantage is that you do not hard code routes in your code.
-    #     # Check that the response is 200 OK.
-    #     self.assertEqual(response.status_code, 200)
-
-    #     # Check that the rendered context contains 1 artist.
-    #     # Response.context is the context variable passed to the template by the view. This is incredibly useful for testing, because it allows us to confirm that our template is getting all the data it needs.
-    #     print(new_employee)
-    #     print(employeeTraining)
-    #     print(training)
-    #     self.assertEqual(training.maxAttendies, 1)
-
-    #     # .encode converts from unicode to utf-8
-    #     # example:
-    #     # If the string is: pythön!
-    #     # The encoded version is: b'pyth\xc3\xb6n!'

--- a/HR/urls.py
+++ b/HR/urls.py
@@ -13,8 +13,6 @@ urlpatterns = [
   path('addemployee/', views.addEmployee, name='addemployee'),
   # edit employee
   path('editemployee/<int:employee_id>/', views.editEmployee, name='editemployee'),
-  # route to edit employee
-  path('editedemployee/<int:employee_id>/', views.editEmployee, name='editedemployee'),
   # department index
   path('departments/', views.departmentIndex, name='departments'),
   # department details
@@ -23,11 +21,16 @@ urlpatterns = [
   path('addDept/', views.addDept, name='addDept'),
   #individual employees
   path('employees/<int:id>/', views.employeedetails, name='employeeDetail'),
+  # trainings list
   path('training/', views.trainingList, name='trainings'),
+  # add training
   path('addTraining/', views.add_training_program, name='add'),
+  # training detail
   path('training/<int:training_id>/', views.trainingDetails, name='trainingDetail'),
+  # edit a training
   path('editTraining/<int:training_id>/', views.edit_training_form, name='edit'),
   path('editedTraining/<int:training_id>/', views.editProgram, name='editedTraining'),
+  # delete a training
   path('trainingDelete/<int:id>/', views.training_delete, name='trainingDelete')
 
 ]

--- a/HR/views/employeeViews.py
+++ b/HR/views/employeeViews.py
@@ -16,11 +16,12 @@ def addEmployee(request):
 
   # if you're on the add employee page
   if request.method == "POST":
-    print("add employee post called")
+    # make variables from individual post requests
     first_name = request.POST["first_name"]
     last_name = request.POST["last_name"]
     start_date = request.POST["start_date"]
     is_supervisor = request.POST["is_supervisor"]
+    # department is a foreign key, so use department's pk
     department_id = get_object_or_404(Department, pk=request.POST["department_id"])
     # create the employee object and save to database
     employee_list = Employee.objects.create(first_name=first_name, last_name=last_name, start_date=start_date, is_supervisor=is_supervisor, department_id=department_id.id)
@@ -30,27 +31,34 @@ def addEmployee(request):
 def editEmployee(request, employee_id):
   # if you're not currently on the add employee page
   if request.method == "GET":
+    # get specific employee object by id
     employee = Employee.objects.get(id=employee_id)
+    # get all dept objects for template dropdown
     department_list = Department.objects.all()
+    # make variables for properties on employee
     first_name = employee.first_name
     last_name = employee.last_name
     start_date = str(employee.start_date)
     is_supervisor = employee.is_supervisor
     department = employee.department
-
+    # context holds employee dictionary
     context = {"employee" : employee, "department_list" : department_list, "first_name" : first_name, "last_name" : last_name, "start_date" : start_date, "is_supervisor" : is_supervisor, "department" : department}
+    # request url, reference template, and give it context
     return render(request, 'HR/employee/editEmployee.html', context)
 
   # if you're on the edit employee page
   if request.method == "POST":
+    # get employee object
     employee = Employee.objects.get(id=employee_id)
+    # make variables from individual post requests
     employee.first_name = request.POST["first_name"]
     employee.last_name = request.POST["last_name"]
     employee.start_date = request.POST["start_date"]
     employee.is_supervisor = request.POST["is_supervisor"]
+    # department is a foreign key, so use department's pk
     employee.department_id = get_object_or_404(Department, pk=request.POST["department_id"])
     employee.save()
-
+    # use url name from urls plus id extension using kwargs and dictionary to assign employee.id
     return HttpResponseRedirect(reverse('HR:employeeDetail', kwargs={'id' : employee.id}))
   
 # Create your views here.


### PR DESCRIPTION
This request contains: 
Finalized testing for employee edit
Cleaned up and added comments to pages related to tickets 2 and 4, and urls page.

Ticket 4 is centered around editing an employee.

Full ticket details: [4](https://github.com/chatty-clownfish/cc-bangazon/issues/4) 

To test ticket 4:
1. Go to employee details page and click the edit button on an employee
2. On edit page, make sure form fields don't crash the page if left empty or filled with incorrectly formatted info.
3. Check to see that the pre-populated forms contain the correct first and last name of the employee
4. Make edits and submit them. You should be taken back to the employee details page and see the updated info.

